### PR TITLE
Fix for Issue #8 introduced an error.

### DIFF
--- a/AD9959.h
+++ b/AD9959.h
@@ -445,7 +445,7 @@ protected:
     static constexpr uint8_t register_length[8] = { 1, 3, 2, 3, 4, 2, 3, 2 };  // And 4 beyond that
 
     uint32_t    rval = 0;
-    int         len = (reg&0x7F) < sizeof(register_length)/sizeof(uint32_t) ? register_length[reg&0x07] : 4;
+    int         len = (reg&0x7F) < sizeof(register_length)/sizeof(uint8_t) ? register_length[reg&0x07] : 4;
     spiBegin();
     SPI.transfer(reg);
     while (len-- > 0)


### PR DESCRIPTION
Hi,

I didn't notice until I just tried to use it, but register_length[] is uint8_t[], not uint32_t[].

-Brandon